### PR TITLE
Remove the redundant getIndexPage method from the Request Resolver.

### DIFF
--- a/io.asgardio.java.oidc.sdk/src/main/java/io/asgardio/java/oidc/sdk/request/OIDCRequestResolver.java
+++ b/io.asgardio.java.oidc.sdk/src/main/java/io/asgardio/java/oidc/sdk/request/OIDCRequestResolver.java
@@ -127,21 +127,6 @@ public class OIDCRequestResolver {
         return request.getRequestURI().contains(callbackContext);
     }
 
-    /**
-     * Returns the index page configured in the {@link OIDCAgentConfig}.
-     *
-     * @return {@link String} IndexPage configured in the {@link OIDCAgentConfig}.
-     */
-    public String getIndexPage() {
-
-        String indexPage = oidcAgentConfig.getIndexPage();
-
-        if (StringUtils.isNotBlank(indexPage)) {
-            return indexPage;
-        }
-        return request.getContextPath();
-    }
-
     private void logErrorAuthorizationResponse(AuthorizationResponse authzResponse) {
 
         AuthorizationErrorResponse errorResponse = authzResponse.toErrorResponse();

--- a/io.asgardio.java.oidc.sdk/src/test/java/io/asgardio/java/oidc/sdk/request/OIDCRequestResolverTest.java
+++ b/io.asgardio.java.oidc.sdk/src/test/java/io/asgardio/java/oidc/sdk/request/OIDCRequestResolverTest.java
@@ -128,26 +128,6 @@ public class OIDCRequestResolverTest extends PowerMockTestCase {
         assertTrue(resolver.isCallbackResponse());
     }
 
-    @DataProvider
-    public Object[][] getIndexPageData() {
-
-        return new Object[][]{
-                {"index.html", "sampleContext", "index.html"},
-                {"", "sampleContext", "sampleContext"}
-        };
-    }
-
-    @Test(dataProvider = "getIndexPageData")
-    public void testGetIndexPage(String indexPageConfig, String contextPath, String expected) {
-
-        OIDCAgentConfig config = new OIDCAgentConfig();
-        config.setIndexPage(indexPageConfig);
-        when(request.getContextPath()).thenReturn(contextPath);
-
-        OIDCRequestResolver resolver = new OIDCRequestResolver(request, config);
-        assertEquals(resolver.getIndexPage(), expected);
-    }
-
     @AfterMethod
     public void tearDown() {
 


### PR DESCRIPTION
## Purpose
getIndexPage() method is not suited to be included in the RequestResolver.class. Since the indexPage property can be obtained from the OIDCAgentConfg: getIndexPage() method, this can be removed.