### PR TITLE
Support refresh token to be optional in the token response.

### DIFF
--- a/io.asgardeo.java.oidc.sdk/src/main/java/io/asgardeo/java/oidc/sdk/DefaultOIDCManager.java
+++ b/io.asgardeo.java.oidc.sdk/src/main/java/io/asgardeo/java/oidc/sdk/DefaultOIDCManager.java
@@ -214,7 +214,10 @@ public class DefaultOIDCManager implements OIDCManager {
             sessionContext.setIdToken(idTokenJWT.getParsedString());
             sessionContext.setUser(user);
             sessionContext.setAccessToken(accessToken.toJSONString());
-            sessionContext.setRefreshToken(refreshToken.getValue());
+            if (refreshToken != null) {
+                sessionContext.setRefreshToken(refreshToken.getValue());
+            }
+
         } catch (ParseException e) {
             throw new SSOAgentServerException(SSOAgentConstants.ErrorMessages.ID_TOKEN_PARSE.getMessage(),
                     SSOAgentConstants.ErrorMessages.ID_TOKEN_PARSE.getCode(), e);


### PR DESCRIPTION
## Purpose
$subject.
As per the spec [1] [2], the refresh token is an optional parameter in the successful token response. This fix is for supporting an optional refresh token parameter in the token response.

[1] https://tools.ietf.org/html/rfc6749#section-5.1
[2] https://openid.net/specs/openid-connect-core-1_0.html#TokenResponse