### PR TITLE
Fix error messages

### DIFF
--- a/io.asgardeo.java.oidc.sdk/src/main/java/io/asgardeo/java/oidc/sdk/DefaultOIDCManager.java
+++ b/io.asgardeo.java.oidc.sdk/src/main/java/io/asgardeo/java/oidc/sdk/DefaultOIDCManager.java
@@ -315,13 +315,13 @@ public class DefaultOIDCManager implements OIDCManager {
         }
 
         if (oidcAgentConfig.getConsumerKey() == null) {
-            throw new SSOAgentClientException(SSOAgentConstants.ErrorMessages.AGENT_CONFIG_CLIENT_SECRET.getMessage(),
-                    SSOAgentConstants.ErrorMessages.AGENT_CONFIG_CLIENT_SECRET.getCode());
+            throw new SSOAgentClientException(SSOAgentConstants.ErrorMessages.AGENT_CONFIG_CLIENT_ID.getMessage(),
+                    SSOAgentConstants.ErrorMessages.AGENT_CONFIG_CLIENT_ID.getCode());
         }
 
         if (oidcAgentConfig.getConsumerSecret() == null) {
-            throw new SSOAgentClientException(SSOAgentConstants.ErrorMessages.AGENT_CONFIG_CLIENT_ID.getMessage(),
-                    SSOAgentConstants.ErrorMessages.AGENT_CONFIG_CLIENT_ID.getCode());
+            throw new SSOAgentClientException(SSOAgentConstants.ErrorMessages.AGENT_CONFIG_CLIENT_SECRET.getMessage(),
+                    SSOAgentConstants.ErrorMessages.AGENT_CONFIG_CLIENT_SECRET.getCode());
         }
 
         if (StringUtils.isEmpty(oidcAgentConfig.getCallbackUrl().toString())) {


### PR DESCRIPTION
## Purpose
Error messages of `oidcAgentConfig.getConsumerKey() == null` and `oidcAgentConfig.getConsumerSecret() == null` should be interchanged.