### PR TITLE
Fix Asgardeo Java OIDC app redirection Issue

### DIFF
--- a/io.asgardeo.java.oidc.sdk/src/main/java/io/asgardeo/java/oidc/sdk/HTTPSessionBasedOIDCProcessor.java
+++ b/io.asgardeo.java.oidc.sdk/src/main/java/io/asgardeo/java/oidc/sdk/HTTPSessionBasedOIDCProcessor.java
@@ -63,6 +63,10 @@ public class HTTPSessionBasedOIDCProcessor {
 
         HttpSession session = request.getSession();
         RequestContext requestContext = defaultOIDCManager.sendForLogin(request, response);
+        if (request.getRequestURI() != null) {
+            String redirectPageURI = request.getRequestURI().substring(request.getContextPath().length() + 1);
+            requestContext.setParameter(SSOAgentConstants.REDIRECT_URI_KEY, redirectPageURI);
+        }
         session.setAttribute(SSOAgentConstants.REQUEST_CONTEXT, requestContext);
     }
 

--- a/io.asgardeo.java.oidc.sdk/src/main/java/io/asgardeo/java/oidc/sdk/SSOAgentConstants.java
+++ b/io.asgardeo.java.oidc.sdk/src/main/java/io/asgardeo/java/oidc/sdk/SSOAgentConstants.java
@@ -49,8 +49,10 @@ public class SSOAgentConstants {
     public static final String CONSUMER_SECRET = "consumerSecret";
     public static final String CALL_BACK_URL = "callBackURL";
     public static final String SKIP_URIS = "skipURIs";
+    public static final String REDIRECT_URI_KEY = "redirectURI";
     public static final String INDEX_PAGE = "indexPage";
     public static final String ERROR_PAGE = "errorPage";
+    public static final String HOME_PAGE = "homePage";
     public static final String LOGOUT_URL = "logoutURL";
     public static final String SCOPE = "scope";
     public static final String OAUTH2_GRANT_TYPE = "grantType";

--- a/io.asgardeo.java.oidc.sdk/src/main/java/io/asgardeo/java/oidc/sdk/config/FileBasedOIDCConfigProvider.java
+++ b/io.asgardeo.java.oidc.sdk/src/main/java/io/asgardeo/java/oidc/sdk/config/FileBasedOIDCConfigProvider.java
@@ -69,6 +69,7 @@ public class FileBasedOIDCConfigProvider implements OIDCConfigProvider {
                 new Secret(properties.getProperty(SSOAgentConstants.CONSUMER_SECRET)) : null;
         String indexPage = properties.getProperty(SSOAgentConstants.INDEX_PAGE);
         String errorPage = properties.getProperty(SSOAgentConstants.ERROR_PAGE);
+        String homePage = properties.getProperty(SSOAgentConstants.HOME_PAGE);
         String logoutURL = properties.getProperty(SSOAgentConstants.LOGOUT_URL);
         JWSAlgorithm jwsAlgorithm =
                 StringUtils.isNotBlank(properties.getProperty(SSOAgentConstants.ID_TOKEN_SIGN_ALG)) ?
@@ -149,6 +150,7 @@ public class FileBasedOIDCConfigProvider implements OIDCConfigProvider {
         oidcAgentConfig.setConsumerSecret(consumerSecret);
         oidcAgentConfig.setIndexPage(indexPage);
         oidcAgentConfig.setErrorPage(errorPage);
+        oidcAgentConfig.setHomePage(homePage);
         oidcAgentConfig.setLogoutURL(logoutURL);
         oidcAgentConfig.setIssuer(issuer);
         oidcAgentConfig.setSkipURIs(skipURIs);

--- a/io.asgardeo.java.oidc.sdk/src/main/java/io/asgardeo/java/oidc/sdk/config/model/OIDCAgentConfig.java
+++ b/io.asgardeo.java.oidc.sdk/src/main/java/io/asgardeo/java/oidc/sdk/config/model/OIDCAgentConfig.java
@@ -38,6 +38,7 @@ public class OIDCAgentConfig {
     private Secret consumerSecret;
     private String indexPage;
     private String errorPage;
+    private String homePage;
     private String logoutURL;
     private URI callbackUrl;
     private Scope scope;
@@ -134,6 +135,26 @@ public class OIDCAgentConfig {
     public void setErrorPage(String errorPage) {
 
         this.errorPage = errorPage;
+    }
+
+    /**
+     * Returns the home page of the OIDC agent.
+     *
+     * @return Home page of the OIDC agent.
+     */
+    public String getHomePage() {
+
+        return homePage;
+    }
+
+    /**
+     * Sets the home page for the OIDC agent.
+     *
+     * @param homePage The home page of the OIDC agent.
+     */
+    public void setHomePage(String homePage) {
+
+        this.homePage = homePage;
     }
 
     /**


### PR DESCRIPTION
## Purpose
Resolves
- https://github.com/wso2-enterprise/asgardeo-product/issues/9654
- https://github.com/asgardeo/asgardeo-tomcat-oidc-agent/issues/11

With this fix 

1. Add support for the target page redirection.
If a user tries to access another secured page (eg: app/myApp) without having an authenticated session with the IdP, the user is first prompted for authentication. Then upon successful authentication, the user is redirected to the original page he tried to access.

2. Improve the SDK to add a redirection page as a new configurable oidc app property. Then the customer can add his custom home page by configuring the property `homePage`. when the application admin has configured this property, the user will always be redirected to the $homePage upon successful authentication regardless of which secured page the user tries to access.