### PR TITLE
Update jadler and log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,13 +214,13 @@
         <nimbusds.version>9.19</nimbusds.version>
         <httpcomponents-apache.wso2.version>4.3.1.wso2v1</httpcomponents-apache.wso2.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <testng.version>7.3.0</testng.version>
         <org.powermock.version>2.0.7</org.powermock.version>
         <mockito.version>3.5.13</mockito.version>
         <mockito.api.version>2.0.7</mockito.api.version>
         <mockserver.version>3.10.8</mockserver.version>
-        <jadler.version>1.3.0</jadler.version>
+        <jadler.version>1.3.1</jadler.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
## Purpose
> Update following dependency version
- jadler-jetty 1.3.0 -> 1.3.1
- log4j          2.17.0 -> 2.17.1

**Related issue**
https://github.com/wso2-enterprise/asgardeo-product/issues/9039