### PR TITLE
Add jadler-jetty with test scope.

### DIFF
--- a/io.asgardeo.java.oidc.sdk/pom.xml
+++ b/io.asgardeo.java.oidc.sdk/pom.xml
@@ -103,6 +103,7 @@
         <dependency>
             <groupId>net.jadler</groupId>
             <artifactId>jadler-jetty</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Description
By adding this dependency scope as a test, we can avoid getting included in the final artifact, which will refrain from triggering the trivy detection.

## Related issue
- https://github.com/wso2-enterprise/asgardeo-product/issues/18105